### PR TITLE
fix: setup script typo

### DIFF
--- a/setup-gotch.sh
+++ b/setup-gotch.sh
@@ -3,7 +3,7 @@
 GOTCH_VERSION="${GOTCH_VER:-v0.7.0}"
 CUDA_VERSION="${CUDA_VER:-11.3}"
 
-if [ -z $GOPATH ] then
+if [ -z $GOPATH ]; then
   $GOPATH="$HOME/go"
 fi
 GOTCH_PATH="$GOPATH/pkg/mod/github.com/sugarme/gotch@$GOTCH_VERSION"


### PR DESCRIPTION
missing a semicolon

https://github.com/sugarme/gotch/blob/ff8504116561be08444b2c2cc9dccec5636ca937/setup-gotch.sh#L6-L8