### PR TITLE
Remove leading `$` in bash variable assignment

### DIFF
--- a/setup-gotch.sh
+++ b/setup-gotch.sh
@@ -4,7 +4,7 @@ GOTCH_VERSION="${GOTCH_VER:-v0.7.0}"
 CUDA_VERSION="${CUDA_VER:-11.3}"
 
 if [ -z $GOPATH ]; then
-  $GOPATH="$HOME/go"
+  GOPATH="$HOME/go"
 fi
 GOTCH_PATH="$GOPATH/pkg/mod/github.com/sugarme/gotch@$GOTCH_VERSION"
 


### PR DESCRIPTION
This fixes a small yet fatal typo that broke setup on my machine.