### PR TITLE
Fix concurrency issue in newTensor

### DIFF
--- a/ts/scalar.go
+++ b/ts/scalar.go
@@ -49,13 +49,13 @@ func newScalarName(nameOpt ...string) string {
 func newScalar(cscalar lib.Cscalar, nameOpt ...string) *Scalar {
 	x := &Scalar{
 		cscalar: cscalar,
-		name:    newName(nameOpt...),
 	}
 
 	atomic.AddInt64(&ScalarCount, 1)
 	nbytes := x.nbytes()
 	atomic.AddInt64(&AllocatedMem, nbytes)
 	lock.Lock()
+	x.name = newName(nameOpt...)
 	ExistingScalars[x.name] = struct{}{}
 	lock.Unlock()
 

--- a/ts/tensor.go
+++ b/ts/tensor.go
@@ -60,7 +60,6 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 	if len(nameOpt) == 0 {
 		nameOpt = []string{}
 	}
-	name := newName(nameOpt...)
 
 	x := new(Tensor)
 	x.ctensor = ctensor
@@ -70,6 +69,7 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 	nbytes := x.nbytes()
 	atomic.AddInt64(&AllocatedMem, nbytes)
 	lock.Lock()
+	name := newName(nameOpt...)
 	if _, ok := ExistingTensors[name]; ok {
 		name = fmt.Sprintf("%s_%09d", name, TensorCount)
 	}


### PR DESCRIPTION
as-is: generated name can be duplicated in multi threaded environment
to-be: move generating name which secured by lock