### PR TITLE
MINOR: Move runtime.SetFinalizer into freeXXX

### DIFF
--- a/ts/scalar.go
+++ b/ts/scalar.go
@@ -20,6 +20,8 @@ func freeCScalar(x *Scalar) error {
 	if gotch.Debug {
 		nbytes := x.nbytes()
 		atomic.AddInt64(&AllocatedMem, -nbytes)
+
+		log.Printf("INFO: Released scalar %q - C memory: %d bytes.\n", x.name, nbytes)
 	}
 	lock.Lock()
 	delete(ExistingScalars, x.name)
@@ -28,10 +30,6 @@ func freeCScalar(x *Scalar) error {
 	lib.AtsFree(x.cscalar)
 	if err := TorchErr(); err != nil {
 		return err
-	}
-
-	if gotch.Debug {
-		log.Printf("INFO: Released scalar %q - C memory: %d bytes.\n", x.name, nbytes)
 	}
 
 	return nil
@@ -58,14 +56,12 @@ func newScalar(cscalar lib.Cscalar, nameOpt ...string) *Scalar {
 	if gotch.Debug {
 		nbytes := x.nbytes()
 		atomic.AddInt64(&AllocatedMem, nbytes)
+
+		log.Printf("INFO: scalar %q added - Allocated memory (%d bytes).\n", x.name, nbytes)
 	}
 	lock.Lock()
 	ExistingScalars[x.name] = struct{}{}
 	lock.Unlock()
-
-	if gotch.Debug {
-		log.Printf("INFO: scalar %q added - Allocated memory (%d bytes).\n", x.name, nbytes)
-	}
 
 	runtime.SetFinalizer(x, freeCScalar)
 

--- a/ts/scalar.go
+++ b/ts/scalar.go
@@ -17,8 +17,10 @@ type Scalar struct {
 
 // free releases C allocated memory.
 func freeCScalar(x *Scalar) error {
-	nbytes := x.nbytes()
-	atomic.AddInt64(&AllocatedMem, -nbytes)
+	if gotch.Debug {
+		nbytes := x.nbytes()
+		atomic.AddInt64(&AllocatedMem, -nbytes)
+	}
 	lock.Lock()
 	delete(ExistingScalars, x.name)
 	lock.Unlock()
@@ -53,8 +55,10 @@ func newScalar(cscalar lib.Cscalar, nameOpt ...string) *Scalar {
 	}
 
 	atomic.AddInt64(&ScalarCount, 1)
-	nbytes := x.nbytes()
-	atomic.AddInt64(&AllocatedMem, nbytes)
+	if gotch.Debug {
+		nbytes := x.nbytes()
+		atomic.AddInt64(&AllocatedMem, nbytes)
+	}
 	lock.Lock()
 	ExistingScalars[x.name] = struct{}{}
 	lock.Unlock()

--- a/ts/tensor.go
+++ b/ts/tensor.go
@@ -70,6 +70,8 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 	if gotch.Debug {
 		nbytes := x.nbytes()
 		atomic.AddInt64(&AllocatedMem, nbytes)
+
+		log.Printf("INFO: Added tensor %q - Allocated memory: %d bytes.\n", x.name, nbytes)
 	}
 	lock.Lock()
 	if _, ok := ExistingTensors[name]; ok {
@@ -79,10 +81,6 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 	lock.Unlock()
 
 	x.name = name
-
-	if gotch.Debug {
-		log.Printf("INFO: Added tensor %q - Allocated memory: %d bytes.\n", x.name, nbytes)
-	}
 
 	x.calledFrom = "newTensor()"
 


### PR DESCRIPTION
I think runtime.SetFinalizer(, nil) in Tensor.Drop is quite confused (runtime.SetFianlizer(x, free) is in newTensor)