### PR TITLE
Fix concurrency bug in generating tensor name

### DIFF
--- a/ts/tensor.go
+++ b/ts/tensor.go
@@ -65,6 +65,7 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 	x.ctensor = ctensor
 	x.d = new(bigStruct)
 
+	lock.Lock()
 	atomic.AddInt64(&TensorCount, 1)
 	if gotch.Debug {
 		nbytes := x.nbytes()
@@ -72,7 +73,6 @@ func newTensor(ctensor lib.Ctensor, nameOpt ...string) *Tensor {
 
 		log.Printf("INFO: Added tensor %q - Allocated memory: %d bytes.\n", x.name, nbytes)
 	}
-	lock.Lock()
 	name := newName(nameOpt...)
 	if _, ok := ExistingTensors[name]; ok {
 		name = fmt.Sprintf("%s_%09d", name, TensorCount)


### PR DESCRIPTION
#110 

TensorCount should be wrapped by lock
- Tensor name came from {PREFIX}_{CURRENT_TENSOR_COUNT}
- atomic Addint64 is good but generating name from this is quite bug prone